### PR TITLE
added name='number' to the credit input field

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -90,7 +90,7 @@
 
               <div class="span3">
                 <label for="">Card number</label>
-                <input type="text" class="input-block-level" ng-model="number" payments-validate="card" payments-format="card" payments-type-model="type" ng-class="myForm.number.$card.type"/>
+                <input type="text" name="number" class="input-block-level" ng-model="number" payments-validate="card" payments-format="card" payments-type-model="type" ng-class="myForm.number.$card.type"/>
               </div>
               
               <div class="span1">


### PR DESCRIPTION
Fix to make the example show the type of credit card as user inputs it. 

There was a change to how Stripe-Form detects values and I do not think the example was ever updated.
