### PR TITLE
Ensuring card length validates properly

### DIFF
--- a/lib/angular-payments.js
+++ b/lib/angular-payments.js
@@ -617,7 +617,14 @@ angular.module('angularPayments', []);angular.module('angularPayments')
           typeModel.assign(scope, card.type);
       }
 
-      ret = (ref = num.length, __indexOf.call(card.length, ref) >= 0) && (card.luhn === false || _luhnCheck(num));
+      var length = 16;
+      switch (card.type) {
+        case 'amex':
+          length = 15;
+          break;
+      }
+
+      ret = (ref = num.length, __indexOf.call(card.length, ref) >= 0) && num.length == length && (card.luhn === false || _luhnCheck(num));
 
       return ret;
   }

--- a/src/validate.js
+++ b/src/validate.js
@@ -98,7 +98,14 @@ angular.module('angularPayments')
           typeModel.assign(scope, card.type);
       }
 
-      ret = (ref = num.length, __indexOf.call(card.length, ref) >= 0) && (card.luhn === false || _luhnCheck(num));
+      var length = 16;
+      switch (card.type) {
+        case 'amex':
+          length = 15;
+          break;
+      }
+
+      ret = (ref = num.length, __indexOf.call(card.length, ref) >= 0) && num.length == length && (card.luhn === false || _luhnCheck(num));
 
       return ret;
   }


### PR DESCRIPTION
Otherwise this will validate early (for instance card number `4242 4242 4242 4242` will pass luhn validation at `4242 4242 4242 42`

I have not updated the minified code as I don't know what minifier you use/don't know what settings are used.

This could probably have been done in a more generic way.