### PR TITLE
Support for new MasterCard BIN 2

### DIFF
--- a/src/cards.js
+++ b/src/cards.js
@@ -56,7 +56,7 @@ angular.module('angularPayments')
       luhn: true
     }, {
       type: 'mastercard',
-      pattern: /^5[1-5]/,
+      pattern: /^(5[1-5]|222[1-9]|22[3-9]|2[3-6]|27[0-1]|2720)/,
       format: defaultFormat,
       inputFormat: defaultInputFormat,
       length: [16],


### PR DESCRIPTION
Mastercard® has received an additional range of 2-series numbers to add to the 5-series that we currently provide. The 2-series BINs operate in the same way as the 5-series and we have made changes to our systems to accommodate the new numbers. Readiness for the 2-series across our issuers, merchants and other partners is tracking on target dates listed below. Mastercard customer financial institutions can expect to be issued 2-series BINs starting in 2017.